### PR TITLE
ci: Work on publishing a docker container

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,21 @@
+kind: pipeline
+name: default
+
+steps:
+- name: docker publish
+  image: plugins/docker
+  settings:
+    username: laduker
+    password:
+      from_secret: dockerhub_token
+    repo: zerotier/pylon
+    tags:
+    - latest
+    - ${DRONE_TAG##v}
+    ssh-agent-key:
+      from_secret: private_key
+  when:
+    branch:
+      - main
+    event:
+      - tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
 FROM debian:bookworm-slim as build
 
-COPY . /code
-WORKDIR /code
-
 RUN apt-get update -qq && apt-get install -y \
   build-essential git make pkg-config cmake libssl-dev
+
+COPY ./ /code
+WORKDIR /code
 
 RUN make release
 
 FROM debian:bookworm-slim
 COPY --from=build /code/pylon /usr/local/bin
+# EXPOSE 443
+# EXPOSE 9993/udp
+# ENV ZT_PYLON_SECRET_KEY=
+# ENV ZT_PYLON_WHITELISTED_PORT=
 ENTRYPOINT [ "/usr/local/bin/pylon" ]
+CMD ["reflect"]


### PR DESCRIPTION
This is a first pass at making this into a docker. I've tested something similar in another repo, but this kind of thing always takes a couple tries -Getting CI to run correctly. 

To test locally, you can do:
`docker build . -t pylon -f Dockerfile  `
`docker run --init -p 443:443 -p 19993:9993/udp -t pylon reflect `
I'm sure this is fine though. 
`refract` should work too, but I haven't practiced getting the args for that correct yet. Maybe we need to pass a file into the container for that to work? 

I have README edits ready too, but will publish them later when we know things are working. 
